### PR TITLE
Match by title or filename as well

### DIFF
--- a/kodisync.js
+++ b/kodisync.js
@@ -54,11 +54,25 @@ async function wait(ms) {
 function playingSameThing(hosts) {
 	if (hosts.length < 2) return true;
 	if (hosts.some((host) => host.playerid == null)) return false;
-	return !hosts.some((host, index) => {
-		if (index === 0) return false;
-		return host.currentItem.showtitle !== hosts[0].currentItem.showtitle
-			|| host.currentItem.season !== hosts[0].currentItem.season
-			|| host.currentItem.episode !== hosts[0].currentItem.episode;
+	return hosts.every((host, index) => {
+		if (index === 0) return true;
+
+		// Check if showtitle, season, and episode information is available (non-empty and not -1)
+		const showInfoAvailable = host.currentItem.showtitle && hosts[0].currentItem.showtitle
+			&& host.currentItem.season !== -1 && hosts[0].currentItem.season !== -1
+			&& host.currentItem.episode !== -1 && hosts[0].currentItem.episode !== -1;
+
+		// Check if showtitle, season, and episode match
+		const showMatches = host.currentItem.showtitle === hosts[0].currentItem.showtitle
+			&& host.currentItem.season === hosts[0].currentItem.season
+			&& host.currentItem.episode === hosts[0].currentItem.episode;
+
+		// Check if title or label matches
+		const titleOrLabelMatches = host.currentItem.title === hosts[0].currentItem.title
+			|| host.currentItem.label === hosts[0].currentItem.label;
+
+		// Use showMatches if showInfoAvailable, otherwise use titleOrLabelMatches
+		return showInfoAvailable ? showMatches : titleOrLabelMatches;
 	});
 }
 
@@ -157,7 +171,7 @@ class Host {
 		if (this.currentItem.showtitle) {
 			return `${this.currentItem.showtitle} ${pad(this.currentItem.season, 2)}x${pad(this.currentItem.episode, 2)}, "${this.currentItem.title}"`;
 		}
-		return this.currentItem.title;
+		return this.currentItem.title || this.currentItem.label;
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@ This is a hacky Node script which attempts to sync playback
 of two or more Kodi instances.
 
 It will wait until all Kodi instances have the same TV show episode loaded
-(by matching show name, season number, episode number)
+(by matching show name, season number, episode number if available;
+otherwise media title or filename)
 and then pause everybody's playback
 and seek them all to the earliest position among the viewers.
 


### PR DESCRIPTION
Thanks for this project, it's very cool and easy to set up for the other person since they just have to open the RPC server.

I often play uncategorized files (no show/season/episode known to kodi) from my downloads source, and I wanted to enhance this script for this use case

1. It will show more helpful info on what's playing (the label/filename)
2. It will not sync completely unrelated videos just because they are not scanned/categorized